### PR TITLE
Install WPS Office

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,22 @@
     - wine
     - zsh
 
+- name: Check for WPS Office
+  stat: path=/opt/kingsoft
+  register: wps
+
+- name: Download WPS Office
+  get_url: url=http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4968~a19_amd64.deb dest=/tmp/wps-office_9.1.0.4968~a19_amd64.deb checksum=sha1:ec0468992aafa7fe5d9975f498aedecdbbe1743f
+  when: wps.stat.exists == False
+
+- name: Install WPS Office
+  apt: deb=/tmp/wps-office_9.1.0.4968~a19_amd64.deb state=present
+  when: wps.stat.exists == False
+
+- name: Remove WPS Office deb
+  file: path=/tmp/wps-office_9.1.0.4968~a19_amd64.deb state=absent
+  when: wps.stat.exists == False
+
 - name: Clobber Google-Chrome.list
   file: path=/etc/apt/sources.list.d/google-chrome.list state=absent
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,7 +88,7 @@
   register: wps
 
 - name: Download WPS Office
-  get_url: url=http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4968~a19_amd64.deb dest=/tmp/wps-office_9.1.0.4968~a19_amd64.deb checksum=sha1:ec0468992aafa7fe5d9975f498aedecdbbe1743f
+  get_url: url=http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4968~a19_amd64.deb dest=/tmp/wps-office_9.1.0.4968~a19_amd64.deb 
   when: wps.stat.exists == False
 
 - name: Install WPS Office


### PR DESCRIPTION
Check to see if any version of WPS Office exists.  If it does not,
download a hard-coded deb file, install it, and delete the file.

In the future, we will need to provide the ability to update WPS Office.
