### PR TITLE
Unattended upgrades

### DIFF
--- a/files/50unattended-upgrades
+++ b/files/50unattended-upgrades
@@ -1,0 +1,59 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+	"${distro_id}:${distro_codename}-security";
+	"${distro_id}:${distro_codename}-updates";
+//	"${distro_id}:${distro_codename}-proposed";
+	"${distro_id}:${distro_codename}-backports";
+};
+
+// List of packages to not update (regexp are supported)
+Unattended-Upgrade::Package-Blacklist {
+//	"vim";
+//	"libc6";
+//	"libc6-dev";
+//	"libc6-i686";
+};
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run 
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGUSR1. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+Unattended-Upgrade::MinimalSteps "true";
+
+// Install all unattended-upgrades when the machine is shuting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+//Unattended-Upgrade::InstallOnShutdown "true";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+//Unattended-Upgrade::Mail "root";
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+//Unattended-Upgrade::MailOnlyOnError "true";
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+//Unattended-Upgrade::Remove-Unused-Dependencies "false";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade 
+//Unattended-Upgrade::Automatic-Reboot "false";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+//Acquire::http::Dl-Limit "70";

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,15 @@
 - name: Accept Microsoft Fonts License
   debconf: name=ttf-mscorefonts-installer question='msttcorefonts/accepted-mscorefonts-eula' value=true vtype=boolean
 
+- name: Allow automatic upgrades
+  debconf: name=unattended-upgrades question='unattended-upgrades/enable_auto_updates' value=true vtype=boolean
+
+- name: Reconfigure unattended-upgrades
+  command: dpkg-reconfigure -u --frontend noninteractive unattended-upgrades
+
+- name: Copy automatic-upgrades config
+  copy: src=50unattended-upgrades dest=etc/apt/apt.conf.d/50unattended-upgrades owner=root group=root mode=0644
+
 - name: Clobber Google-Chrome.list
   file: path=/etc/apt/sources.list.d/google-chrome.list state=absent
 

--- a/tasks/wps.yml
+++ b/tasks/wps.yml
@@ -4,15 +4,15 @@
   register: wps
 
 - name: Download WPS Office
-  get_url: url=http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4968~a19_amd64.deb dest=/tmp/wps-office_9.1.0.4968~a19_amd64.deb
+  get_url: url=http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4975~a19p1_amd64.deb dest=/tmp/wps-office_9.1.0.4975~a19p1_amd64.deb
   when: wps.stat.exists == False
 
 - name: Install WPS Office
-  apt: deb=/tmp/wps-office_9.1.0.4968~a19_amd64.deb state=present
+  apt: deb=/tmp/wps-office_9.1.0.4975~a19p1_amd64.deb state=present
   when: wps.stat.exists == False
 
 - name: Remove WPS Office deb
-  file: path=/tmp/wps-office_9.1.0.4968~a19_amd64.deb state=absent
+  file: path=/tmp/wps-office_9.1.0.4975~a19p1_amd64.deb state=absent
   when: wps.stat.exists == False
 
 - name: Install Microsoft Fonts

--- a/tasks/wps.yml
+++ b/tasks/wps.yml
@@ -1,18 +1,16 @@
 ---
+- include_vars: wps.yml
+
 - name: Check for WPS Office
-  stat: path=/opt/kingsoft
+  stat: path=/opt/kingsoft/{{ wpsUrl | regex_replace('.*/', '') }}
   register: wps
 
 - name: Download WPS Office
-  get_url: url=http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4975~a19p1_amd64.deb dest=/tmp/wps-office_9.1.0.4975~a19p1_amd64.deb
+  get_url: url={{ wpsUrl }} dest=/opt/kingsoft/{{ wpsUrl | regex_replace('.*/', '') }}
   when: wps.stat.exists == False
 
 - name: Install WPS Office
-  apt: deb=/tmp/wps-office_9.1.0.4975~a19p1_amd64.deb state=present
-  when: wps.stat.exists == False
-
-- name: Remove WPS Office deb
-  file: path=/tmp/wps-office_9.1.0.4975~a19p1_amd64.deb state=absent
+  apt: deb=/opt/kingsoft/{{ wpsUrl | regex_replace('.*/', '') }} state=present
   when: wps.stat.exists == False
 
 - name: Install Microsoft Fonts

--- a/vars/wps.yml
+++ b/vars/wps.yml
@@ -1,0 +1,1 @@
+wpsUrl: http://kdl.cc.ksosoft.com/wps-community/download/a19/wps-office_9.1.0.4975~a19p1_amd64.deb


### PR DESCRIPTION
We're using the unattended-upgrades package with our own settings.
Mainly, we'll never force-reboot, but we want to update all packages,
both critical security fixes, and small tweaks.  Specifically,
-security, -updates, and -backports, but never -proposed (just like apt)
