### PR TITLE
Install R and Pavucontrol fixes #28

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,8 @@
     - eclipse
     - git
     - openjdk-7-jdk
+    - r-base
+    - r-base-dev
     - spim
 
 - name: Install additional editors
@@ -76,6 +78,7 @@
     - keepass2
     - mlocate
     - mosh
+    - pavucontrol
     - redshift
     - rxvt-unicode-256color
     - shutter


### PR DESCRIPTION
r-base and r-base-dev were requested by Joe and Tiffany for a class.
Additionally, users of a minimal window manager may find pavucontrol a
convenient way to manage their volume.
