### PR TITLE
Add Matlab Menu to Desktop

### DIFF
--- a/files/matlab.desktop
+++ b/files/matlab.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Matlab
+GenericName=The Language of Technical Computing
+Exec=xterm -e /usr/local/sbin/matlab.sh
+Terminal=false
+Type=Application
+Categories=Science;Math;

--- a/files/matlab.sh
+++ b/files/matlab.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export SSHPASS=$(zenity --info --text="Matlab is hosted on UTDallas servers.  To access it, you will need to enter your UTD (not CollegiumV) password.  Your password will not be stored"; zenity --password --title="UTD Password");
+sshpass -e ssh -tX $(ldapsearch -LLL -h b '(uid='"`whoami`"')' netID 2>/dev/null | sed -n 's/^[ \t]*netID:[ \t]*\(.*\)/\1/p;')@giant.utdallas.edu 'bash -l -c matlab';
+SSHPASS=''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,7 @@
     - rxvt-unicode-256color
     - shutter
     - sl
+    - sshpass
     - tcpdump
     - tmux
     - tree
@@ -240,6 +241,12 @@
 
 - name: Add Old Session Killer to Crontab
   copy: src=cleanup dest=/etc/cron.d/cleanup owner=root group=root mode=0544
+
+- name: Copy Matlab script
+  copy: src=matlab.sh dest=/usr/local/sbin/matlab.sh owner=root group=root mode=0755
+
+- name: Copy Matlab menu item
+  copy: src=matlab.desktop dest=/usr/share/applications/matlab.desktop owner=root group=root mode=644
 
 - include: wps.yml
 


### PR DESCRIPTION
The trick in this commit is to get SSH with X-Forwarding, without
requiring the user to type anything in the terminal.  To do this, we
must execute the script within a terminal (xterm), and use sshpass.

For password authentication, we use the sshpass recommended method of
storing the password (which we request with Zenity) in a local variable.
We then ssh with all the special options and run Matlab inside of bash.
It works.

If a user enters their password wrong, the terminal will close, and it
will fail silently.
