### PR TITLE
Add boost library

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,7 @@
     - shelldap
     - spim
     - rust-stable
+    - libboost-all-dev
 
 - name: Install additional editors
   apt: name={{ item }} state=present


### PR DESCRIPTION
It has useful things and this is better than people untarring the entirety of the library into their home folder. 
Also, CS1 uses it, so this brings lounge computers closer to other on campus computers in standards.
