### PR TITLE
Add Cinnamon PPA and Packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     - ppa:keithw/mosh
     - ppa:klaus-vormweg/awesome
     - ppa:videolan/stable-daily
-    - ppa:lestcape/cinnamon
+    - ppa:kranich/cinnamon
     - ppa:hansjorg/rust
 
 - name: Add Google Chrome Repository
@@ -27,6 +27,7 @@
     - awesome-extra
     - i3
     - xfce4
+    - "^cinnamon-.+"
   notify:
     - lightdm
 


### PR DESCRIPTION
Before pushing this please run `sudo add-apt-repository -r
ppa:lestcape/cinnamon` on all clients to remove the previous, abandoned
cinnamon repo.

Now that Cinnamon has gotten rid of the problems with cinnamon-preload
in linuxmint/cinnamon@22beb89574dfd10672cfbc5ebae043eb79a21d5b we can
include it.
