### PR TITLE
Install Gnupg-agent for Pass integration and more

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,8 +80,9 @@
     - kaffeine
     - dtrx
     - firefox
-    - google-chrome-stable
     - gap
+    - gnupg-agent
+    - google-chrome-stable
     - htop
     - icedtea-plugin
     - keepass2


### PR DESCRIPTION
Some lounge users would like to use Pass, the standard UNIX password
manager.  Pass usage is extremely limited without a GPG-agent, including
any browser integration.  This is a complicated package that is not
easily installed in a user's home directory.

Adding this package will enable users to not only use Pass, but also
other GPG-dependant applications, including encryption in email and the
like.

I have tested it on Niblick, and confirmed that it works without any
consequences.
