### PR TITLE
Add gnome-screenshot for cinnamon

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,6 +105,7 @@
     - evince
     - feh
     - fuse-exfat
+    - gnome-screenshot
     - gnupg2
     - google-fonts-ttf
     - htop


### PR DESCRIPTION
Cinnamon uses gnome-screenshot by default.

About to add documentation as well.